### PR TITLE
Handle jdk lib loading and use newer jdbc drivers

### DIFF
--- a/cfn-templates/cft.yaml
+++ b/cfn-templates/cft.yaml
@@ -369,20 +369,25 @@ Resources:
               mkdir -p "$WORKING_DIR"
 
               # Download Hive JDBC Jar file for Hive connection on Amazon EMR
-              cd "$WORKING_DIR" && wget https://repo1.maven.org/maven2/org/apache/hive/hive-jdbc/2.3.6/hive-jdbc-2.3.6-standalone.jar
+              #cd "$WORKING_DIR" && wget https://repo1.maven.org/maven2/org/apache/hive/hive-jdbc/2.3.6/hive-jdbc-2.3.6-standalone.jar
+              cd "$WORKING_DIR" && wget https://repo1.maven.org/maven2/org/apache/hive/hive-jdbc/3.1.3/hive-jdbc-3.1.3-standalone.jar
 
               # Download Presto JBBC Jar file for Presto connection on Amazon EMR
-              cd "$WORKING_DIR" && wget https://repo1.maven.org/maven2/com/facebook/presto/presto-jdbc/0.232/presto-jdbc-0.232.jar
+              #cd "$WORKING_DIR" && wget https://repo1.maven.org/maven2/com/facebook/presto/presto-jdbc/0.232/presto-jdbc-0.232.jar
+              cd "$WORKING_DIR" && wget https://repo1.maven.org/maven2/com/facebook/presto/presto-jdbc/0.281/presto-jdbc-0.281.jar
 
               # Download Redshift JDBC Jar file for Amazon Redshift connection
-              cd "$WORKING_DIR" && wget https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/1.2.45.1069/RedshiftJDBC42-no-awssdk-1.2.45.1069.jar
+              #cd "$WORKING_DIR" && wget https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/1.2.45.1069/RedshiftJDBC42-no-awssdk-1.2.45.1069.jar
+              cd "$WORKING_DIR" && wget https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.14/redshift-jdbc42-2.1.0.14.jar
 
               # Download Athena JDBC Jar file for Amazon Athena connection
-              cd "$WORKING_DIR" && wget https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.9/AthenaJDBC42_2.0.9.jar
+              #cd "$WORKING_DIR" && wget https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.9/AthenaJDBC42_2.0.9.jar
+              cd "$WORKING_DIR" && wget https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-2.0.36.1000/AthenaJDBC42-2.0.36.1000.jar
 
               # Download MariaDB JDBC Jar file for Aurora MySQL connection
-              cd "$WORKING_DIR" && wget https://downloads.mariadb.com/Connectors/java/connector-java-2.6.0/mariadb-java-client-2.6.0.jar
-               
+              #cd "$WORKING_DIR" && wget https://downloads.mariadb.com/Connectors/java/connector-java-2.6.0/mariadb-java-client-2.6.0.jar
+              cd "$WORKING_DIR" && wget https://downloads.mariadb.com/Connectors/java/connector-java-3.1.3/mariadb-java-client-3.1.3.jar
+
               EOF
       OnStart:
         - Content:

--- a/notebooks/athena_connect.ipynb
+++ b/notebooks/athena_connect.ipynb
@@ -15,7 +15,12 @@
    "source": [
     "jar_dir <- \"~/SageMaker/jdbc\"\n",
     "jar_file <- list.files(jar_dir, pattern = \"Athena\")\n",
-    "jar_dir_file <- file.path(jar_dir,jar_file)"
+    "jar_dir_file <- file.path(jar_dir,jar_file)\n",
+    "libjvm_path <- system(\"find /usr/lib/jvm/ -name libjvm.so\", intern=TRUE)\n",
+    "libjvm_path\n",
+    "dyn.load(libjvm_path)\n",
+    "\n",
+    "options( java.parameters = \"-Xmx8g\" )"
    ]
   },
   {
@@ -43,8 +48,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "region <- system(\"curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq .region -r\",intern=TRUE)\n",
-    "jdbc_string <- paste(\"jdbc:awsathena://AwsRegion=\",region,\";S3OutputLocation=s3://\",s3_bucket,\"/;AwsCredentialsProviderClass=com.simba.athena.amazonaws.auth.DefaultAWSCredentialsProviderChain\",sep=\"\")"
+    "session_token <- system(\"curl -X PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600'\",intern=TRUE)\n",
+    "session_token\n",
+    "region_lookup_cmd <- paste( \"curl -H \\\"X-aws-ec2-metadata-token: \", session_token, \"\\\"  -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq .region -r\")\n",
+    "region <-  system(region_lookup_cmd,intern=TRUE)\n",
+    "jdbc_string <- paste(\"jdbc:awsathena://AwsRegion=\",region,\";S3OutputLocation=s3://\",s3_bucket,\"/;AwsCredentialsProviderClass=com.simba.athena.amazonaws.auth.DefaultAWSCredentialsProviderChain\",sep=\"\")\n",
+    "jdbc_string\n"
    ]
   },
   {
@@ -58,7 +67,8 @@
     "library(RJDBC)\n",
     "options( java.parameters = \"-Xmx8g\" )\n",
     "drv <- JDBC(\"com.simba.athena.jdbc.Driver\",jar_dir_file,identifier.quote=\"`\")\n",
-    "conn <- dbConnect(drv, jdbc_string)"
+    "conn <- dbConnect(drv, jdbc_string)\n",
+    "conn"
    ]
   },
   {
@@ -78,6 +88,13 @@
    "outputs": [],
    "source": [
     "dbListObjects(conn)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Modify or replace with valid date ranges in the SELECT query"
    ]
   },
   {
@@ -111,9 +128,9 @@
    "mimetype": "text/x-r-source",
    "name": "R",
    "pygments_lexer": "r",
-   "version": "3.6.1"
+   "version": "4.2.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/notebooks/aurora_connect.ipynb
+++ b/notebooks/aurora_connect.ipynb
@@ -15,7 +15,12 @@
    "source": [
     "jar_dir <- \"~/SageMaker/jdbc\"\n",
     "jar_file <- list.files(jar_dir, pattern = \"mariadb\")\n",
-    "jar_dir_file <- file.path(jar_dir,jar_file)"
+    "jar_dir_file <- file.path(jar_dir,jar_file)\n",
+    "libjvm_path <- system(\"find /usr/lib/jvm/ -name libjvm.so\", intern=TRUE)\n",
+    "libjvm_path\n",
+    "dyn.load(libjvm_path)\n",
+    "\n",
+    "options( java.parameters = \"-Xmx8g\" )"
    ]
   },
   {
@@ -154,9 +159,9 @@
    "mimetype": "text/x-r-source",
    "name": "R",
    "pygments_lexer": "r",
-   "version": "3.6.1"
+   "version": "4.2.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/notebooks/hive_connect.ipynb
+++ b/notebooks/hive_connect.ipynb
@@ -15,7 +15,12 @@
    "source": [
     "jar_dir <- \"~/SageMaker/jdbc\"\n",
     "jar_file <- list.files(jar_dir, pattern = \"hive\")\n",
-    "jar_dir_file <- file.path(jar_dir,jar_file)"
+    "jar_dir_file <- file.path(jar_dir,jar_file)\n",
+    "libjvm_path <- system(\"find /usr/lib/jvm/ -name libjvm.so\", intern=TRUE)\n",
+    "libjvm_path\n",
+    "dyn.load(libjvm_path)\n",
+    "\n",
+    "options( java.parameters = \"-Xmx8g\" )"
    ]
   },
   {
@@ -109,7 +114,7 @@
    "mimetype": "text/x-r-source",
    "name": "R",
    "pygments_lexer": "r",
-   "version": "3.6.1"
+   "version": "4.2.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/presto_connect.ipynb
+++ b/notebooks/presto_connect.ipynb
@@ -15,7 +15,12 @@
    "source": [
     "jar_dir <- \"~/SageMaker/jdbc\"\n",
     "jar_file <- list.files(jar_dir, pattern = \"presto\")\n",
-    "jar_dir_file <- file.path(jar_dir,jar_file)"
+    "jar_dir_file <- file.path(jar_dir,jar_file)\n",
+    "libjvm_path <- system(\"find /usr/lib/jvm/ -name libjvm.so\", intern=TRUE)\n",
+    "libjvm_path\n",
+    "dyn.load(libjvm_path)\n",
+    "\n",
+    "options( java.parameters = \"-Xmx8g\" )"
    ]
   },
   {
@@ -109,9 +114,9 @@
    "mimetype": "text/x-r-source",
    "name": "R",
    "pygments_lexer": "r",
-   "version": "3.6.1"
+   "version": "4.2.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/notebooks/redshift_connect.ipynb
+++ b/notebooks/redshift_connect.ipynb
@@ -14,8 +14,13 @@
    "outputs": [],
    "source": [
     "jar_dir <- \"~/SageMaker/jdbc\"\n",
-    "jar_file <- list.files(jar_dir, pattern = \"Redshift\")\n",
-    "jar_dir_file <- file.path(jar_dir,jar_file)"
+    "jar_file <- list.files(jar_dir, pattern = \"redshift\")\n",
+    "jar_dir_file <- file.path(jar_dir,jar_file)\n",
+    "libjvm_path <- system(\"find /usr/lib/jvm/ -name libjvm.so\", intern=TRUE)\n",
+    "libjvm_path\n",
+    "dyn.load(libjvm_path)\n",
+    "\n",
+    "options( java.parameters = \"-Xmx8g\" )"
    ]
   },
   {
@@ -134,9 +139,9 @@
    "mimetype": "text/x-r-source",
    "name": "R",
    "pygments_lexer": "r",
-   "version": "3.6.1"
+   "version": "4.2.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
*Issue #, if available:* Failure in loading jdbc drivers inside R sagemaker notebook and insufficient permissions for connecting to Athena 

*Description of changes:* JDBC driver loading fails due to libjvm library loading failures and additionally there are newer drivers (athena also uses newer IMDSv2 for trusted auto-cred lookup from metadata service).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
